### PR TITLE
Prepare for zbus 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ keywords = ["dbus", "systemd", "Linux", "zbus", "async"]
 license = "MIT/Apache-2.0"
 name = "zbus_systemd"
 repository = "https://github.com/lucab/zbus_systemd"
-version = "0.0.4"
+version = "0.0.5"
 
 [dependencies]
 futures = "0.3"
 serde = "1"
-zbus = "2"
+zbus = "3"
 
 [dev-dependencies]
 tokio = {version = "1", features = ["full"]}


### PR DESCRIPTION
Upstream zbus is preparing its `3.0` release. This PR prepares `zbus_systemd` for it.