### PR TITLE
zbus_systemd: release 0.25600.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["dbus", "systemd", "Linux", "zbus", "async"]
 license = "MIT/Apache-2.0"
 name = "zbus_systemd"
 repository = "https://github.com/lucab/zbus_systemd"
-version = "0.0.17"
+version = "0.25600.0"
 rust-version = "1.75.0"
 
 [dependencies]


### PR DESCRIPTION
First release getting rid of the initial experimental `0.0` version prefix.
This starts using a better versioning scheme. The `minor` field now keeps track of the corresponding systemd version too, as follow:
 * the last two digits (`00` here) are an incremental counter reserved for our own version bumps
 * all the prefix digits (`256` here) are the systemd version used as the base for interface definitions