### PR TITLE
Add unit name escape helpers

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -92,6 +92,72 @@ pub fn bus_path_decode<'a>(
     Some(bus_label_unescape(label))
 }
 
+/// Escape a unit name
+///
+/// Based on `unit_name_escape` from `systemd`.
+pub fn unit_name_escape(input: &str) -> Cow<'_, str> {
+    const VALID_CHARS: &str = r"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz:_.";
+
+    if input.chars().next() != Some('.') && input.chars().all(|c| VALID_CHARS.contains(c)) {
+        return Cow::Borrowed(input);
+    }
+
+    let mut result = String::with_capacity(input.len());
+
+    let escape_char = |c: char, result: &mut String| {
+        use std::fmt::Write;
+
+        result.push('\\');
+        result.push('x');
+        _ = write!(result, "{:02x}", c as u8);
+    };
+
+    let mut chars = input.chars().peekable();
+
+    // Handle leading '.' separately
+    if let Some(c) = chars.next_if_eq(&'.') {
+        escape_char(c, &mut result);
+    }
+
+    for c in chars {
+        match c {
+            '/' => result.push('-'),
+            c if VALID_CHARS.contains(c) => result.push(c),
+            c => escape_char(c, &mut result),
+        }
+    }
+
+    Cow::Owned(result)
+}
+
+/// Unescape a unit name
+///
+/// Based on `unit_name_unescape` from `systemd`.
+pub fn unit_name_unescape(f: &str) -> Option<Cow<'_, str>> {
+    if f.chars().all(|c| c != '\\' && c != '-') {
+        return Some(Cow::Borrowed(f));
+    }
+
+    let mut result = String::with_capacity(f.len());
+    let mut chars = f.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '-' => result.push('/'),
+            '\\' => {
+                if chars.next() != Some('x') {
+                    return None;
+                }
+                let a = chars.next().and_then(|c| c.to_digit(16))?;
+                let b = chars.next().and_then(|c| c.to_digit(16))?;
+                result.push(((a << 4) | b) as u8 as char);
+            }
+            _ => result.push(c),
+        }
+    }
+
+    Some(Cow::Owned(result))
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -159,5 +225,40 @@ mod test {
             ),
             Some("".into())
         );
+    }
+
+    #[test]
+    fn test_unit_name_escape() {
+        assert_eq!(unit_name_escape(""), Cow::Borrowed(""));
+        assert_eq!(
+            unit_name_escape("ab+-c.a/bc@foo.service"),
+            Cow::<'static, str>::Owned(r"ab\x2b\x2dc.a-bc\x40foo.service".to_string())
+        );
+        assert_eq!(
+            unit_name_escape("foo.service"),
+            Cow::Borrowed("foo.service")
+        );
+        assert_eq!(
+            unit_name_escape(".foo.service"),
+            Cow::<'static, str>::Owned(r"\x2efoo.service".to_string())
+        );
+    }
+
+    #[test]
+    fn test_unit_name_unescape() {
+        assert_eq!(unit_name_unescape(""), Some(Cow::Borrowed("")));
+        assert_eq!(
+            unit_name_unescape(r"ab\x2b\x2dc.a-bc\x40foo.service"),
+            Some(Cow::Owned("ab+-c.a/bc@foo.service".to_string()))
+        );
+        assert_eq!(
+            unit_name_unescape("foo.service"),
+            Some(Cow::Borrowed("foo.service"))
+        );
+        assert_eq!(
+            unit_name_unescape(r"\x2efoo.service"),
+            Some(Cow::Owned(".foo.service".to_string()))
+        );
+        assert_eq!(unit_name_unescape(r"\x2"), None);
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -98,15 +98,13 @@ pub fn bus_path_decode<'a>(
 pub fn unit_name_escape(input: &str) -> Cow<'_, str> {
     const VALID_CHARS: &str = r"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz:_.";
 
-    if input.chars().next() != Some('.') && input.chars().all(|c| VALID_CHARS.contains(c)) {
+    if !input.starts_with('.') && input.chars().all(|c| VALID_CHARS.contains(c)) {
         return Cow::Borrowed(input);
     }
 
     let mut result = String::with_capacity(input.len());
 
     let escape_char = |c: char, result: &mut String| {
-        use std::fmt::Write;
-
         result.push('\\');
         result.push('x');
         _ = write!(result, "{:02x}", c as u8);


### PR DESCRIPTION
Just like the bus labels, but for unit names. [Based on the systemd implementations](https://github.com/systemd/systemd/blob/5121f7c45b37afca53c89f42123b1dd6a04fa80f/src/basic/unit-name.c#L334)