### PR TITLE
zbus_systemd: release 0.25700.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["dbus", "systemd", "Linux", "zbus", "async"]
 license = "MIT/Apache-2.0"
 name = "zbus_systemd"
 repository = "https://github.com/lucab/zbus_systemd"
-version = "0.25600.1"
+version = "0.25700.0"
 rust-version = "1.75.0"
 
 [dependencies]


### PR DESCRIPTION
Changes:
 * systemd: bump to v257
 * sysupdate1: add support for `org.freedesktop.sysupdate1`
 * timesync1: add support for `org.freedesktop.timesync1`