### PR TITLE
fix: disable heavy zbus dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,13 @@ rust-version = "1.77.0"
 [dependencies]
 futures = "0.3"
 serde = "1"
-zbus = "5.3"
+zbus = { version = "5.3", default-features = false }
 
 [dev-dependencies]
 tokio = {version = "1", features = ["full"]}
 
 [features]
+default = ["zbus_default_features"]
 home1 = []
 hostname1 = []
 import1 = []
@@ -34,6 +35,7 @@ systemd1 = []
 sysupdate1 = []
 timedate1 = []
 timesync1 = []
+zbus_default_features = ["zbus/default"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
The zbus crate has some heavy features that massively slow down compilation times. zbus_systemd does not, on it's own, need these; therefore, they can be disabled by removing the default feature `zbus_default_features`.

This feature is part of the `default` set to avoid breaking changes.

If users need more zbus features, they simply need to add the `zbus` crate to their own Cargo.toml with the features they need, the crate resolver will include these.