### PR TITLE
zbus_systemd: release 0.26100.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["dbus", "systemd", "Linux", "zbus", "async"]
 license = "MIT/Apache-2.0"
 name = "zbus_systemd"
 repository = "https://github.com/lucab/zbus_systemd"
-version = "0.26000.0"
+version = "0.26100.0"
 rust-version = "1.87.0"
 
 [dependencies]


### PR DESCRIPTION
Changes:
 * ci: update and pin actions
 * systemd: bump to v261